### PR TITLE
Ensure when date parsed on item creation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,17 @@ app.get("/api/items", async (req, res) => {
 
 app.post("/api/items", requireAdmin, async (req, res) => {
   const { type, title, data = {}, tags = [], when = null } = req.body;
-  const created = await prisma.item.create({ data: { type, title, data, tags, when } });
+
+  const created = await prisma.item.create({
+    data: {
+      type,
+      title,
+      data,
+      tags,
+      when: when ? new Date(when) : null
+    }
+  });
+
   res.json(created);
 });
 


### PR DESCRIPTION
## Summary
- Parse incoming `when` field into a `Date` or `null` when creating items

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b21b0d0010832aa0ec02cea05e0657