### PR TITLE
Restore item routes and server start

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,3 +76,26 @@ app.post("/api/items", requireAdmin, async (req, res) => {
 app.patch("/api/items/:id", requireAdmin, async (req, res) => {
   const { id } = req.params;
   const { type, title, data = {}, tags = [], when } = req.body;
+
+  const updated = await prisma.item.update({
+    where: { id },
+    data: {
+      type,
+      title,
+      data,
+      tags,
+      when: when === undefined ? undefined : when ? new Date(when) : null
+    }
+  });
+
+  res.json(updated);
+});
+
+app.delete("/api/items/:id", requireAdmin, async (req, res) => {
+  await prisma.item.delete({ where: { id: req.params.id } });
+  res.json({ ok: true });
+});
+
+app.listen(PORT, () => {
+  console.log(`everythingApp listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- Complete PATCH `/api/items/:id` handler to update records and return the saved item
- Reintroduce DELETE `/api/items/:id` route with admin requirement
- Add server startup logging with app.listen

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm start` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68b22399cfe8832a9f077fc1d9968e85